### PR TITLE
Upsert, InsertIfMissing and Bulk support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 Denntah.Sql.sln
+Denntah.Sql.Test.sln
 .vs
 **/bin
 **/obj
+.DS_Store

--- a/Denntah.Sql.Test/BulkTest.cs
+++ b/Denntah.Sql.Test/BulkTest.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Data;
+using System.Linq;
+using Denntah.Sql.Test.Models;
+using Xunit;
+
+namespace Denntah.Sql.Test
+{
+    [Collection("DBTest")]
+    public class BulkTest : IDisposable
+    {
+        private IDbConnection _db;
+
+        public BulkTest()
+        {
+            _db = DatabaseFactory.Connect();
+        }
+
+        [Fact]
+        public void InsertMany()
+        {
+            var personList = Enumerable.Range(0, 100).Select(i => new Person
+            {
+                FirstName = "FirstName" + i,
+                LastName = "LastName " + i,
+                Gender = Gender.Female,
+                DateCreated = DateTime.Now
+            }).AsEnumerable();
+
+            int rowsAffected = _db.Insert("persons", personList);
+
+            Assert.Equal(100, rowsAffected);
+        }
+
+        [Fact]
+        public void InsertManyIfMissing()
+        {
+            var carList = Enumerable.Range(0, 100).Select(i => new Car
+            {
+                Id = "CCC" + i,
+                Make = "Car " + i
+            });
+
+            int insertCount1 = _db.InsertIfMissing("cars", carList.Take(25), "id");
+            var insertCount2 = _db.InsertIfMissing("cars", carList, "id");
+
+            Assert.Equal(25, insertCount1);
+            Assert.Equal(75, insertCount2);
+        }
+
+        [Fact]
+        public void UpsertMany()
+        {
+            var carList = Enumerable.Range(0, 100).Select(i => new Car
+            {
+                Id = "DDD" + i,
+                Make = "Car " + i
+            });
+
+            var result1 = _db.Upsert("cars", carList, "id").ToList();
+            int insertCount = result1.Count(inserted => inserted);
+
+            var result2 = _db.Upsert("cars", carList, "id").ToList();
+            int updateCount = result2.Count(inserted => !inserted);
+
+            Assert.Equal(100, insertCount);
+            Assert.Equal(100, updateCount);
+        }
+
+        public void Dispose()
+        {
+            _db.Dispose();
+        }
+
+    }
+}

--- a/Denntah.Sql.Test/Car.cs
+++ b/Denntah.Sql.Test/Car.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Denntah.Sql.Test.Models
+{
+    [Table("cars")]
+    public class Car
+    {
+        [Key]
+        public string Id { get; set; }
+        public string Make { get; set; }
+        [Generated]
+        public DateTime DateRegistered { get; set; }
+    }
+}

--- a/Denntah.Sql.Test/CarTest.cs
+++ b/Denntah.Sql.Test/CarTest.cs
@@ -1,0 +1,86 @@
+using Denntah.Sql.Test.Models;
+using System;
+using System.Data;
+using System.Linq;
+using Xunit;
+
+namespace Denntah.Sql.Test
+{
+    [Collection("DBTest")]
+    public class CarTest : IDisposable
+    {
+        private IDbConnection _db;
+
+        public CarTest()
+        {
+            _db = DatabaseFactory.Connect();
+        }
+
+        [Fact]
+        public void InsertAndUpsert()
+        {
+            Car _data = new Car
+            {
+                Id = "AAA001",
+                Make = "Audi S4"
+            };
+
+            _db.Insert("cars", _data);
+
+            _data.Make = "BMW M5";
+            bool isInsert = _db.Upsert("cars", _data, "id");
+
+            Car car = _db.Query<Car>("SELECT * FROM cars WHERE id=@Id", _data).FirstOrDefault();
+
+            Assert.False(isInsert);
+            Assert.Equal(_data.Make, car.Make);
+        }
+
+        [Fact]
+        public void UpsertAndUpsert()
+        {
+            Car _data = new Car
+            {
+                Id = "AAA002",
+                Make = "VW Passat"
+            };
+
+            bool isInsert = _db.Upsert("cars", _data, "id");
+
+            _data.Make = "Volvo V70";
+            bool isUpdate = !_db.Upsert("cars", _data, "id");
+
+            Car car = _db.Query<Car>("SELECT * FROM cars WHERE id=@Id", _data).FirstOrDefault();
+
+            Assert.True(isInsert);
+            Assert.True(isUpdate);
+            Assert.Equal(_data.Make, car.Make);
+        }
+
+        [Fact]
+        public void InsertIfMissing()
+        {
+            Car _data = new Car
+            {
+                Id = "AAA003",
+                Make = "Ferrari F40"
+            };
+
+            int affected = _db.InsertIfMissing("cars", _data, "id");
+
+            _data.Make = "Lamborghini Aventador";
+            int affected2 = _db.InsertIfMissing("cars", _data, "id");
+
+            Car car = _db.Query<Car>("SELECT * FROM cars WHERE id=@Id", _data).FirstOrDefault();
+
+            Assert.Equal(1, affected);
+            Assert.Equal(0, affected2);
+            Assert.Equal("Ferrari F40", car.Make);
+        }
+
+        public void Dispose()
+        {
+            _db.Dispose();
+        }
+    }
+}

--- a/Denntah.Sql.Test/DatabaseFixture.cs
+++ b/Denntah.Sql.Test/DatabaseFixture.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Denntah.Sql.Test
+{
+    public class DatabaseFixture
+    {
+        public DatabaseFixture()
+        {
+            DatabaseFactory.CreatePostgres();
+        }
+    }
+
+    [CollectionDefinition("DBTest")]
+    public class DBTest : ICollectionFixture<DatabaseFixture> { }
+}

--- a/Denntah.Sql.Test/DocumentTest.cs
+++ b/Denntah.Sql.Test/DocumentTest.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Denntah.Sql.Test
 {
+    [Collection("DBTest")]
     public class DocumentTest : IDisposable
     {
         private IDbConnection _db;
@@ -14,7 +15,7 @@ namespace Denntah.Sql.Test
 
         public DocumentTest()
         {
-            _db = DatabaseFactory.CreatePostgres();
+            _db = DatabaseFactory.Connect();
 
             _data = new Document
             {

--- a/Denntah.Sql.Test/ObjectTest.cs
+++ b/Denntah.Sql.Test/ObjectTest.cs
@@ -1,13 +1,11 @@
-﻿using Denntah.Sql.Reflection;
-using Denntah.Sql.Test.Models;
+﻿using Denntah.Sql.Test.Models;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Xunit;
 
 namespace Denntah.Sql.Test
 {
+    [Collection("DBTest")]
     public class ObjectTest
     {
         [Fact]
@@ -16,7 +14,7 @@ namespace Denntah.Sql.Test
             Person person = null;
             int id = 0;
 
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
             {
                 id = db.Insert<int>("persons", new Person { FirstName = "Foo" }, "id");
                 person = db.Get<Person>(id);
@@ -30,14 +28,14 @@ namespace Denntah.Sql.Test
         [Fact]
         public void GetObjectWithoutKey()
         {
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
                 Assert.Throws<ArgumentException>(() => db.Get<Document>(Guid.NewGuid()));
         }
 
         [Fact]
         public void GetObjectWhereKeyCountDoesntMatch()
         {
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
                 Assert.Throws<ArgumentException>(() => db.Get<Person>(1, 2));
         }
 
@@ -50,7 +48,7 @@ namespace Denntah.Sql.Test
                 LastName = "Bar"
             };
 
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
                 db.Insert(person);
 
             Assert.True(person.Id > 0);
@@ -67,7 +65,7 @@ namespace Denntah.Sql.Test
 
             int affected;
 
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
                 affected = db.Insert(document);
 
             Assert.True(affected == 1);
@@ -84,7 +82,7 @@ namespace Denntah.Sql.Test
                 LastName = "Bar"
             };
 
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
             {
                 db.Insert(person);
                 person.FirstName = "Baz";
@@ -105,6 +103,90 @@ namespace Denntah.Sql.Test
         }
 
         [Fact]
+        public void UpsertObject()
+        {
+            bool isInsert;
+            bool isUpdate;
+
+            Car car = new Car
+            {
+                Id = "BBB001",
+                Make = "VW Golf"
+            };
+
+            using (var db = DatabaseFactory.Connect())
+            {
+                db.Delete(car);
+
+                isInsert = db.Upsert(car);
+
+                car.Make = "Ford Focus";
+                isUpdate = !db.Upsert(car);
+
+                car = db.Get<Car>(car.Id);
+            }
+
+            Assert.True(isInsert);
+            Assert.True(isUpdate);
+            Assert.Equal("BBB001", car.Id);
+            Assert.Equal("Ford Focus", car.Make);
+        }
+
+        [Fact]
+        public void UpsertObjectWithoutKey()
+        {
+            Document document = new Document
+            {
+                Name = "somedocument.txt"
+            };
+
+            using (var db = DatabaseFactory.Connect())
+                Assert.Throws<ArgumentException>(() => db.Upsert(document));
+        }
+
+        [Fact]
+        public void InsertObjectIfMissing()
+        {
+            int affected;
+            int affected2;
+
+            Car car = new Car
+            {
+                Id = "BBB002",
+                Make = "Saab 9000"
+            };
+
+            using (var db = DatabaseFactory.Connect())
+            {
+                db.Delete(car);
+
+                affected = db.InsertIfMissing(car);
+
+                car.Make = "Seat Leon";
+                affected2 = db.InsertIfMissing(car);
+
+                car = db.Get<Car>(car.Id);
+            }
+
+            Assert.Equal(1, affected);
+            Assert.Equal(0, affected2);
+            Assert.Equal("BBB002", car.Id);
+            Assert.Equal("Saab 9000", car.Make);
+        }
+
+        [Fact]
+        public void InsertObjectIfMissingWithoutKey()
+        {
+            Document document = new Document
+            {
+                Name = "somedocument.txt"
+            };
+
+            using (var db = DatabaseFactory.Connect())
+                Assert.Throws<ArgumentException>(() => db.InsertIfMissing(document));
+        }
+
+        [Fact]
         public void UpdateObjectWithoutKey()
         {
             Document document = new Document
@@ -112,7 +194,7 @@ namespace Denntah.Sql.Test
                 Name = "foo.txt"
             };
 
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
                 Assert.Throws<ArgumentException>(() => db.Update(document));
         }
 
@@ -127,7 +209,7 @@ namespace Denntah.Sql.Test
                 LastName = "Bar"
             };
 
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
             {
                 db.Insert(person);
 
@@ -145,7 +227,7 @@ namespace Denntah.Sql.Test
                 Name = "foo.txt"
             };
 
-            using (var db = DatabaseFactory.CreatePostgres())
+            using (var db = DatabaseFactory.Connect())
                 Assert.Throws<ArgumentException>(() => db.Delete(document));
         }
     }

--- a/Denntah.Sql/Command.cs
+++ b/Denntah.Sql/Command.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Text;
+using System.Linq;
 
 namespace Denntah.Sql
 {
@@ -63,6 +63,33 @@ namespace Denntah.Sql
                     value = value.ToString();
 
                 cmd.ApplyParameter(property.Property.Name, value ?? DBNull.Value);
+            }
+        }
+
+        /// <summary>
+        /// Add parameters to an indexed bulk command
+        /// </summary>
+        /// <param name="cmd">Command to add parameters to</param>
+        /// <param name="argsList">List of objects that holds the parameters</param>
+        public static void ApplyParameters(this IDbCommand cmd, IEnumerable<object> argsList = null)
+        {
+            if (argsList == null) return;
+
+            var typeDescriber = TypeHandler.Get(argsList.First());
+
+            int i = 0;
+            foreach (var args in argsList)
+            {
+                foreach (var property in typeDescriber.Arguments)
+                {
+                    var value = typeDescriber.GetValue(property.Property.Name, args);
+
+                    if (property.Property.PropertyType.IsEnum)
+                        value = value.ToString();
+
+                    cmd.ApplyParameter(property.Property.Name + i, value ?? DBNull.Value);
+                }
+                i++;
             }
         }
     }


### PR DESCRIPTION
## New methods
- Upsert
Inserts, or updates if pk already exists. Uses ```ON CONFLICT (pk) DO UPDATE```
Requires a primary key which is not autogenerated.

- InsertIfMissing
Inserts if pk not exists, otherwise ignores. Uses ```ON CONFLICT (pk) DO NOTHING```
Useful for creating dimension/lookup tables on the fly. 
Requires a primary key which is not autogenerated.

## Bulk
Insert, InsertIfMissing, Upsert will accept a list of objects to generate a long list of values with indexed parameters. 1000000 cars was inserted in 40sec which seems fairly good on my 2013 laptop, but can probably be improved.

## Misc
- DatabaseFactory syncs database timezone with code or many tests can fail where asserting dates if user forgot to set a database timezone.

- Added DatabaseFixture.cs as an entrypoint so the database it setup only once before each test-run. This fixes some occasional "IF NOT EXISTS" race-conditions and will not cause ObjectTest.InsertObjectWithoutKey to fail the 2nd time.
